### PR TITLE
add <ul> styling for tables

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -16,3 +16,10 @@ table {
 tr:nth-child(even) td {
     background-color: $color-bg-tint;
 }
+
+table ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    line-height: 1;
+}


### PR DESCRIPTION
Could we style `<ul>` elements in tables differently from the default? At the moment I use an ugly workaround with `<br>` elements to achieve this styling within a table.