### PR TITLE
restrict summary styling to accordion

### DIFF
--- a/scss/kub.scss
+++ b/scss/kub.scss
@@ -33,7 +33,7 @@ img {
     margin-bottom: $spacer;
 }
 
-summary {
+.accordion-summary {
     @extend h3;
     cursor: pointer;
 

--- a/static/accordion.js
+++ b/static/accordion.js
@@ -32,7 +32,9 @@ if (body) {
     while (i--) {
         var node = body.childNodes[i];
         if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === 'H3') {
-            prependChild(sections[0], wrap(node, 'summary'));
+            var summary = wrap(node, 'summary');
+            summary.className = 'accordion-summary';
+            prependChild(sections[0], summary);
             sections.unshift(document.createElement('details'));
         } else {
             prependChild(sections[0], node);


### PR DESCRIPTION
This will allow us to use `<details>` and `<summary>` elements in other places.