### PR TITLE
adjust marker in truncate() to tinyMCE6

### DIFF
--- a/main.php
+++ b/main.php
@@ -3,7 +3,7 @@
 include_once('datasource.php');
 
 function truncate($body, $truncate) {
-	$marker = '<hr class="system-read-more" />';
+	$marker = '<hr class="system-read-more">';
 	$parts = explode($marker, $body);
 	if ($truncate) {
 		return $parts[0];


### PR DESCRIPTION
If you add "read more" via tinyMCE the function truncate() is no longer working because tinyMCE adds `<hr class="system-read-more">` and no longer `<hr class="system-read-more" />`. Maybe this changed with tinyMCE6? You can also no longer force `/>` in the source code editor, maybe to conform to the HTML5 standard?