### PR TITLE
Load campaigns dynamically

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -65,6 +65,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			'show_in_nav' => isset($_POST['show_in_nav']),
 			'id' => $page_id,
 		));
+		// add or update twingle id for campaign pages
+		if (isset($_POST['twid'])) {
+			$campaign = get_campaign_by_page_id($page_id);
+			if ($campaign) {
+				$updateStmt = $db->prepare('UPDATE campaigns SET twid=:twid WHERE page=:page');
+				$updateStmt->execute(array(
+					'twid' => $_POST['twid'],
+					'page' => $page_id
+				));
+			} else {
+				$insertStmt = $db->prepare('INSERT INTO campaigns (page, twid) VALUES (:page, :twid)');
+				$insertStmt->execute(array(
+					'page' => $page_id,
+					'twid' => $_POST['twid']
+				));
+			}
+		}
 		header("Location: ?page=$page_id&lang={$lang['code']}", true, 302);
 	} elseif ($_GET['action'] === 'edit-translation') {
 		$stmt = $db->prepare('UPDATE translations SET title=:title, body=:body WHERE page=:page AND lang=:lang');

--- a/admin/index.php
+++ b/admin/index.php
@@ -145,7 +145,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			</label>
 
 			<label id="twid">
-				Twingle ID
+				Spenden ID (Twingle)
 				<input name="twid" id="twid_input" type="text" value="<?php e($page['twid']) ?>">
 			</label>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -56,14 +56,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 		$stmt->execute(array('id' => $page_id));
 		header("Location: ?", true, 302);
 	} elseif ($_GET['action'] === 'edit-page') {
-		$stmt = $db->prepare('UPDATE pages SET slug=:slug, layout=:layout, order_by=:order_by, published=:published, show_in_nav=:show_in_nav, twid=:twid WHERE id=:id');
+		$stmt = $db->prepare('UPDATE pages SET slug=:slug, layout=:layout, order_by=:order_by, published=:published, show_in_nav=:show_in_nav, twingle_id=:twingle_id WHERE id=:id');
 		$stmt->execute(array(
 			'slug' => $_POST['slug'],
 			'layout' => $_POST['layout'],
 			'order_by' => $_POST['order_by'],
 			'published' => isset($_POST['published']),
 			'show_in_nav' => isset($_POST['show_in_nav']),
-			'twid' => !empty($_POST['twid']) ? $_POST['twid'] : null,
+			'twingle_id' => !empty($_POST['twingle_id']) ? $_POST['twingle_id'] : null,
 			'id' => $page_id,
 		));
 		header("Location: ?page=$page_id&lang={$lang['code']}", true, 302);
@@ -138,15 +138,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			<label>
 				Layout
 				<select name="layout" id="layout">
-					<?php foreach (array('default', 'overview', 'blog', 'home', 'contact', 'accordion', 'tandem', 'spenden') as $value): ?>
+					<?php foreach (array('default', 'overview', 'blog', 'home', 'contact', 'accordion', 'tandem') as $value): ?>
 						<option <?php if ($page['layout'] === $value) : ?>selected<?php endif ?>><?php e($value) ?></option>
 					<?php endforeach ?>
 				</select>
 			</label>
 
-			<label id="twid">
+			<label>
 				Spenden ID (Twingle)
-				<input name="twid" id="twid_input" type="text" value="<?php e($page['twid']) ?>">
+				<input name="twingle_id" type="text" value="<?php e($page['twingle_id']) ?>">
 			</label>
 
 			<label>

--- a/admin/index.php
+++ b/admin/index.php
@@ -81,6 +81,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 } else {
 	$page = get_page_by_id($page_id);
 	$root = get_page_by_id(1);
+	$campaign = null;
+	if ($page['layout'] === 'spenden') {
+		$campaign = get_campaign_by_page_id($page_id);
+	}
 
 	$translation = get_translation($page_id, $lang['code']);
 	if (!$translation) {
@@ -137,11 +141,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			<label>
 				Layout
 				<select name="layout">
-					<?php foreach (array('default', 'overview', 'blog', 'home', 'contact', 'accordion', 'tandem', 'spenden', 'spenden-ccv', 'foerderkreis', 'foerderkreis-briefaktion') as $value) : ?>
+					<?php foreach (array('default', 'overview', 'blog', 'home', 'contact', 'accordion', 'tandem', 'spenden') as $value): ?>
 						<option <?php if ($page['layout'] === $value) : ?>selected<?php endif ?>><?php e($value) ?></option>
 					<?php endforeach ?>
 				</select>
 			</label>
+
+			<?php if ($page['layout'] === 'spenden'): ?>
+				<label>
+					Twingle ID
+					<input name="twid" type="text" value="<?php e($campaign['twid']) ?? '' ?>" required>
+				</label>
+			<?php endif ?>
 
 			<label>
 				Order

--- a/admin/index.php
+++ b/admin/index.php
@@ -140,19 +140,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 			<label>
 				Layout
-				<select name="layout">
+				<select name="layout" id="layout">
 					<?php foreach (array('default', 'overview', 'blog', 'home', 'contact', 'accordion', 'tandem', 'spenden') as $value): ?>
 						<option <?php if ($page['layout'] === $value) : ?>selected<?php endif ?>><?php e($value) ?></option>
 					<?php endforeach ?>
 				</select>
 			</label>
 
-			<?php if ($page['layout'] === 'spenden'): ?>
-				<label>
-					Twingle ID
-					<input name="twid" type="text" value="<?php e($campaign['twid']) ?? '' ?>" required>
-				</label>
-			<?php endif ?>
+			<label id="twid" style="display: none;">
+				Twingle ID
+				<?php $value = $campaign ? $campaign['twid'] : '' ?>
+				<input name="twid" id="twid_input" type="text" value="<?php e($value) ?>">
+			</label>
 
 			<label>
 				Order

--- a/admin/static/admin.js
+++ b/admin/static/admin.js
@@ -65,3 +65,26 @@ if (textarea) {
 		},
 	});
 }
+
+// show/hide the twingle id field based on layout selection
+const layout = document.getElementById("layout");
+const twid = document.getElementById("twid");
+const twidInput = document.getElementById("twid_input");
+function showOrHideTwingle() {
+  const value = layout.value;
+  if (value === "spenden") {
+    // show element and make required
+    twid.style.display = "";
+    twidInput.setAttribute("required", "");
+    twidInput.focus();
+  } else {
+    // hide element and remove requirement
+    twid.style.display = "none";
+    twidInput.removeAttribute("required");
+    twidInput.value = "";
+  }
+}
+// run on change
+layout.addEventListener("change", showOrHideTwingle);
+// run on initial load
+document.addEventListener("DOMContentLoaded", showOrHideTwingle);

--- a/admin/static/admin.js
+++ b/admin/static/admin.js
@@ -76,7 +76,6 @@ function showOrHideTwingle() {
     // show element and make required
     twid.style.display = "";
     twidInput.setAttribute("required", "");
-    twidInput.focus();
   } else {
     // hide element and remove requirement
     twid.style.display = "none";

--- a/admin/static/admin.js
+++ b/admin/static/admin.js
@@ -74,11 +74,11 @@ function showOrHideTwingle() {
   const value = layout.value;
   if (value === "spenden") {
     // show element and make required
-    twid.style.display = "";
+    twid.hidden = false;
     twidInput.setAttribute("required", "");
   } else {
     // hide element and remove requirement
-    twid.style.display = "none";
+    twid.hidden = true;
     twidInput.removeAttribute("required");
     twidInput.value = "";
   }

--- a/admin/static/admin.js
+++ b/admin/static/admin.js
@@ -65,25 +65,3 @@ if (textarea) {
 		},
 	});
 }
-
-// show/hide the twingle id field based on layout selection
-const layout = document.getElementById("layout");
-const twid = document.getElementById("twid");
-const twidInput = document.getElementById("twid_input");
-function showOrHideTwingle() {
-  const value = layout.value;
-  if (value === "spenden") {
-    // show element and make required
-    twid.hidden = false;
-    twidInput.setAttribute("required", "");
-  } else {
-    // hide element and remove requirement
-    twid.hidden = true;
-    twidInput.removeAttribute("required");
-    twidInput.value = "";
-  }
-}
-// run on change
-layout.addEventListener("change", showOrHideTwingle);
-// run on initial load
-document.addEventListener("DOMContentLoaded", showOrHideTwingle);

--- a/console/update-campaigns.php
+++ b/console/update-campaigns.php
@@ -3,7 +3,7 @@
 include_once(__DIR__ . '/../datasource.php');
 
 /** 
- * This script creates and fills the 'campaigns' table 
+ * This script adds a 'twid' column to the 'pages' table and fills it
  * with the twingle ID's of the respective campaign-related layouts.
  * It also updates the layout names of the 'pages' entries
  * to a unified 'spenden' layout.
@@ -11,17 +11,18 @@ include_once(__DIR__ . '/../datasource.php');
  * Run in terminal via `php console/update-campaigns.php` 
  */
 
+
 const CAMPAIGN_LAYOUTS = ["spenden", "spenden-ccv", "foerderkreis", "foerderkreis-briefaktion"];
 
-// add new campaigns table
-$db->query('DROP TABLE IF EXISTS campaigns;');
-$db->query("CREATE TABLE IF NOT EXISTS campaigns (
-                id INTEGER PRIMARY KEY /*!40101 AUTO_INCREMENT */,
-                page INTEGER NOT NULL,
-                twid VARCHAR(50) NOT NULL,
-                FOREIGN KEY (page) REFERENCES pages(id) ON DELETE CASCADE,
-                UNIQUE (page, twid)
-            );");
+const VALUES = [
+    ['slug' => 'spenden', 'twid' => 'kub-spenden-allgemein/tw64df2b7d9f960'],
+    ['slug' => 'ccvossel', 'twid' => 'kub-ccvossel/tw65fc34564f0c6'],
+    ['slug' => 'foerderkreis', 'twid' => 'foerderkreis/tw656d9a25844ef'],
+    ['slug' => 'foerderkreis-briefaktion', 'twid' => 'foerderkreis-briefaktion/tw684bcdc396b26'],
+];
+
+$db->query("DROP TABLE IF EXISTS campaigns");
+//$db->query("ALTER TABLE pages DROP COLUMN twid;"); // reset for testing purposes
 
 // fetch pages with campaign layouts
 $placeholders = implode(',', array_fill(0, count(CAMPAIGN_LAYOUTS), '?'));
@@ -34,58 +35,33 @@ if (count($donatePages) < 1) {
     echo "No campaign layouts found.\nExiting without changes.\n";
 }
 
-echo "Found campaign layouts in 'pages' table:\n";
-foreach ($donatePages as $donatePage) {
-    echo "  ID: " . $donatePage['id'] . ", Layout: " . $donatePage['layout'] . ", Slug: " . $donatePage['slug'] . "\n";
-}
-
-echo "\nInserting entries to 'campaigns' table...\n";
-
-// prepare data for campaigns table
-$values = [];
-foreach ($donatePages as $page) {
-    switch ($page['slug']) {
-        case 'spenden':
-            $values[] = ['page' => $page['id'], 'twid' => 'kub-spenden-allgemein/tw64df2b7d9f960'];
-            break;
-        case 'ccvossel':
-            $values[] = ['page' => $page['id'], 'twid' => 'kub-ccvossel/tw65fc34564f0c6'];
-            break;
-        case 'foerderkreis':
-            $values[] = ['page' => $page['id'], 'twid' => 'foerderkreis/tw656d9a25844ef'];
-            break;
-        case 'foerderkreis-briefaktion':
-            $values[] = ['page' => $page['id'], 'twid' => 'foerderkreis-briefaktion/tw684bcdc396b26'];
-            break;
-        default:
-            break;
-    }
-}
-
-// insert data into campaigns table
-try {
-    $stmt = $db->prepare("INSERT INTO campaigns (page, twid) VALUES (:page, :twid);");
-    foreach ($values as $row) {
-        echo "  Writing twingle ID '" . $row['twid'] . "' for page ID '" . $row['page'] . "'...\n";
-        $stmt->execute($row);
-    }
-} catch (PDOException $e) {
-    echo "\nError inserting campaigns: " . $e->getMessage() . "\n";
-    exit(0);
-}
-
 // update layout names in pages table to unified 'spenden' layout
-echo "\nUpdating campaign layouts in 'pages' table...\n";
-
+echo "\nUnifying campaign layouts to 'spenden'...\n";
 foreach ($donatePages as $page) {
-    $newLayout = 'spenden';
-    echo "  Updating page ID " . $page['id'] . " layout from '" . $page['layout'] . "' to '" . $newLayout . "'...\n";
-    $updateStmt = $db->prepare("UPDATE pages SET layout=:layout WHERE id=:id;");
     try {
-        $updateStmt->execute(['layout' => $newLayout, 'id' => $page['id']]);
+        $renameStmt = $db->prepare("UPDATE pages SET layout=:layout WHERE id=:id;");
+        $renameStmt->execute(['layout' => 'spenden', 'id' => $page['id']]);
     } catch (PDOException $e) {
         echo "\nError updating layout: " . $e->getMessage() . "\n";
     }
+}
+
+// add twid column to pages table
+echo "Adding new 'twid' column to the 'pages' table...\n";
+$db->query("ALTER TABLE pages ADD twid VARCHAR(50);");
+
+// write twid values for existing campaign pages
+$updateStmt = $db->prepare("UPDATE pages SET twid=:twid WHERE slug=:slug AND layout=:layout;");
+echo "Writing 'twid' values to 'pages' table...\n";
+try {
+    foreach (VALUES as $row) {
+        $row['layout'] = 'spenden';
+        $updateStmt->execute($row);
+        $updateStmt->closeCursor();
+    }
+} catch (PDOException $e) {
+    echo "\nError writing twingle IDs: " . $e->getMessage() . "\n";
+    exit(0);
 }
 
 echo "\nDone.\n";

--- a/console/update-campaigns.php
+++ b/console/update-campaigns.php
@@ -1,0 +1,93 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+include_once(__DIR__ . '/../datasource.php');
+
+/** 
+ * This script creates and fills the 'campaigns' table 
+ * with the twingle ID's of the respective campaign-related layouts.
+ * It also updates the layout names of the 'pages' entries
+ * to a unified 'spenden' layout.
+ * 
+ * Run in terminal via `php console/update-campaigns.php` 
+ */
+
+const CAMPAIGN_LAYOUTS = ["spenden", "spenden-ccv", "foerderkreis", "foerderkreis-briefaktion"];
+
+// add new campaigns table
+$db->query('DROP TABLE IF EXISTS campaigns;');
+$db->query("CREATE TABLE IF NOT EXISTS campaigns (
+                id INTEGER PRIMARY KEY /*!40101 AUTO_INCREMENT */,
+                page INTEGER NOT NULL,
+                twid VARCHAR(50) NOT NULL,
+                FOREIGN KEY (page) REFERENCES pages(id) ON DELETE CASCADE,
+                UNIQUE (page, twid)
+            );");
+
+// fetch pages with campaign layouts
+$placeholders = implode(',', array_fill(0, count(CAMPAIGN_LAYOUTS), '?'));
+$sql = "SELECT id, layout, slug FROM pages WHERE layout IN ($placeholders)";
+$stmt = $db->prepare($sql);
+$stmt->execute(CAMPAIGN_LAYOUTS);
+$donatePages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+if (count($donatePages) < 1) {
+    echo "No campaign layouts found.\nExiting without changes.\n";
+}
+
+echo "Found campaign layouts in 'pages' table:\n";
+foreach ($donatePages as $donatePage) {
+    echo "  ID: " . $donatePage['id'] . ", Layout: " . $donatePage['layout'] . ", Slug: " . $donatePage['slug'] . "\n";
+}
+
+echo "\nInserting entries to 'campaigns' table...\n";
+
+// prepare data for campaigns table
+$values = [];
+foreach ($donatePages as $page) {
+    switch ($page['slug']) {
+        case 'spenden':
+            $values[] = ['page' => $page['id'], 'twid' => 'kub-spenden-allgemein/tw64df2b7d9f960'];
+            break;
+        case 'ccvossel':
+            $values[] = ['page' => $page['id'], 'twid' => 'kub-ccvossel/tw65fc34564f0c6'];
+            break;
+        case 'foerderkreis':
+            $values[] = ['page' => $page['id'], 'twid' => 'foerderkreis/tw656d9a25844ef'];
+            break;
+        case 'foerderkreis-briefaktion':
+            $values[] = ['page' => $page['id'], 'twid' => 'foerderkreis-briefaktion/tw684bcdc396b26'];
+            break;
+        default:
+            break;
+    }
+}
+
+// insert data into campaigns table
+try {
+    $stmt = $db->prepare("INSERT INTO campaigns (page, twid) VALUES (:page, :twid);");
+    foreach ($values as $row) {
+        echo "  Writing twingle ID '" . $row['twid'] . "' for page ID '" . $row['page'] . "'...\n";
+        $stmt->execute($row);
+    }
+} catch (PDOException $e) {
+    echo "\nError inserting campaigns: " . $e->getMessage() . "\n";
+    exit(0);
+}
+
+// update layout names in pages table to unified 'spenden' layout
+echo "\nUpdating campaign layouts in 'pages' table...\n";
+
+foreach ($donatePages as $page) {
+    $newLayout = 'spenden';
+    echo "  Updating page ID " . $page['id'] . " layout from '" . $page['layout'] . "' to '" . $newLayout . "'...\n";
+    $updateStmt = $db->prepare("UPDATE pages SET layout=:layout WHERE id=:id;");
+    try {
+        $updateStmt->execute(['layout' => $newLayout, 'id' => $page['id']]);
+    } catch (PDOException $e) {
+        echo "\nError updating layout: " . $e->getMessage() . "\n";
+    }
+}
+
+echo "\nDone.\n";
+exit(0);
+?>

--- a/datasource.php
+++ b/datasource.php
@@ -17,7 +17,7 @@ $db->query("CREATE TABLE IF NOT EXISTS pages (
 	published BOOLEAN,
 	show_in_nav BOOLEAN,
 	parent INTEGER,
-    twid VARCHAR(50),
+    twingle_id VARCHAR(50),
 	FOREIGN KEY (parent) REFERENCES pages(id) ON DELETE CASCADE,
 	UNIQUE (slug, parent)
 );");

--- a/datasource.php
+++ b/datasource.php
@@ -29,13 +29,21 @@ $db->query("CREATE TABLE IF NOT EXISTS translations (
 	FOREIGN KEY (page) REFERENCES pages(id) ON DELETE CASCADE,
 	UNIQUE (page, lang)
 );");
-
 try {
 	$db->query("INSERT INTO pages
 		(id, slug, layout, order_by, published, show_in_nav, parent)
 		VALUES (1, '', 'home', 10, 1, 0, NULL)
 	;");
 } catch (PDOException) {}
+
+/* add twingle campaigns table */
+$db->query("CREATE TABLE IF NOT EXISTS campaigns (
+    id INTEGER PRIMARY KEY /*!40101 AUTO_INCREMENT */,
+    page INTEGER NOT NULL,
+    twid VARCHAR(50) NOT NULL,
+    FOREIGN KEY (page) REFERENCES pages(id) ON DELETE CASCADE,
+    UNIQUE (page, twid)
+);");
 
 function fetch_or_404($stmt)
 {

--- a/datasource.php
+++ b/datasource.php
@@ -82,6 +82,14 @@ function get_page_by_id($id)
 	return fetch_or_404($stmt);
 }
 
+function get_campaign_by_page_id($id)
+{
+	global $db;
+	$stmt = $db->prepare('SELECT * FROM campaigns WHERE page=:page');
+	$stmt->execute(array('page' => $id));
+	return $stmt->fetch();
+}
+
 function get_page_by_path($path, $include_pub = false)
 {
 	global $db;

--- a/datasource.php
+++ b/datasource.php
@@ -74,14 +74,6 @@ function get_page_by_id($id)
 	return fetch_or_404($stmt);
 }
 
-function get_campaign_by_page_id($id)
-{
-	global $db;
-	$stmt = $db->prepare('SELECT * FROM campaigns WHERE page=:page');
-	$stmt->execute(array('page' => $id));
-	return $stmt->fetch();
-}
-
 function get_page_by_path($path, $include_pub = false)
 {
 	global $db;

--- a/datasource.php
+++ b/datasource.php
@@ -17,6 +17,7 @@ $db->query("CREATE TABLE IF NOT EXISTS pages (
 	published BOOLEAN,
 	show_in_nav BOOLEAN,
 	parent INTEGER,
+    twid VARCHAR(50),
 	FOREIGN KEY (parent) REFERENCES pages(id) ON DELETE CASCADE,
 	UNIQUE (slug, parent)
 );");
@@ -35,15 +36,6 @@ try {
 		VALUES (1, '', 'home', 10, 1, 0, NULL)
 	;");
 } catch (PDOException) {}
-
-/* add twingle campaigns table */
-$db->query("CREATE TABLE IF NOT EXISTS campaigns (
-    id INTEGER PRIMARY KEY /*!40101 AUTO_INCREMENT */,
-    page INTEGER NOT NULL,
-    twid VARCHAR(50) NOT NULL,
-    FOREIGN KEY (page) REFERENCES pages(id) ON DELETE CASCADE,
-    UNIQUE (page, twid)
-);");
 
 function fetch_or_404($stmt)
 {

--- a/main.php
+++ b/main.php
@@ -144,13 +144,6 @@ try {
 	validate_path($path);
 
 	$page = get_page_by_path($path);
-
-	// add twingle id for campaign pages
-	if($page['layout'] === 'spenden') {
-		$campaign = get_campaign_by_page_id($page['id']);
-		$page['twid'] = $campaign['twid'] ?? null;
-	}
-
 	add_content($page, $lang);
 	$area = path_shift($path)[0];
 	if (!empty($area)) {

--- a/main.php
+++ b/main.php
@@ -144,6 +144,13 @@ try {
 	validate_path($path);
 
 	$page = get_page_by_path($path);
+
+	// add twingle id for campaign pages
+	if($page['layout'] === 'spenden') {
+		$campaign = get_campaign_by_page_id($page['id']);
+		$page['twid'] = $campaign['twid'] ?? null;
+	}
+
 	add_content($page, $lang);
 	$area = path_shift($path)[0];
 	if (!empty($area)) {

--- a/templates/main.php
+++ b/templates/main.php
@@ -149,21 +149,10 @@
 					</aside>
 				<?php elseif ($page['layout'] === 'spenden') : ?>
 					<aside class="l-side">
-						<?php spenden('kub-spenden-allgemein/tw64df2b7d9f960') ?>
+						<!-- load campaigns dynamically -->
+						<?php spenden($page['twid']) ?>
 					</aside>
-				<?php elseif ($page['layout'] === 'spenden-ccv') : ?>
-					<aside class="l-side">
-						<?php spenden('kub-ccvossel/tw65fc34564f0c6') ?>
-					</aside>
-				<?php elseif ($page['layout'] === 'foerderkreis') : ?>
-					<aside class="l-side">
-						<?php spenden('foerderkreis/tw656d9a25844ef') ?>
-					</aside>
-				<?php elseif ($page['layout'] === 'foerderkreis-briefaktion') : ?>
-					<aside class="l-side">
-						<?php spenden('foerderkreis-briefaktion/tw684bcdc396b26') ?>
-					</aside>
-				<?php elseif (has_side_nav()) : ?>
+				<?php elseif (has_side_nav()): ?>
 					<nav id="section-nav" class="l-side" aria-label="<?php e($areapage['title']) ?>">
 						<?php render_side_nav() ?>
 					</nav>

--- a/templates/main.php
+++ b/templates/main.php
@@ -147,15 +147,15 @@
 					<aside class="l-side">
 						<?php include('map.php') ?>
 					</aside>
-				<?php elseif ($page['layout'] === 'spenden') : ?>
-					<aside class="l-side">
-						<!-- load campaigns dynamically -->
-						<?php spenden($page['twid']) ?>
-					</aside>
 				<?php elseif (has_side_nav()): ?>
 					<nav id="section-nav" class="l-side" aria-label="<?php e($areapage['title']) ?>">
 						<?php render_side_nav() ?>
 					</nav>
+				<?php endif ?>
+				<?php if (!empty($page['twingle_id'])) : ?>
+					<aside class="l-side">
+						<?php spenden($page['twingle_id']) ?>
+					</aside>
 				<?php endif ?>
 			<?php endif ?>
 		</div>


### PR DESCRIPTION
_Note: Directly after the merge, the new console command must be executed to keep the campaign pages working:_
`php console/update-campaigns.php`

### Changes in code

- Added a new database table `campaigns`. It contains the twingle ID's (`twid`) and maps them to the respective pages.
- Added a console command that does two things:
  - it fills the `campaigns` table with the existing `twid` values
  - it updates all campaign related page layout names to 'spenden'
- Removed all other campaign layout names (other than 'spenden') from frontend appearance
- Added an input field with the name 'Twingle ID' to the admin UI:
  - it appears only if the layout 'spenden' was selected
  - when visible, it is also required to be filled
  - after clicking "Save", the value passed to this field is then inserted (or updated) as `twid` in the `campaigns` db table
- Updated the guests' view to dynamically load the twingle campaigns via the current _$page_

### Changes for users (admins)

- There is only one campaign related layout left that can be selected: 'spenden'
- This layout name is now shared by all campaign pages
- Now, when adding a new donation campaign:
  - you always need to assign the 'spenden' layout
  - you need to add the 'Twingle ID' of the campaign
  - no change: you keep assigning a unique slug, just as before